### PR TITLE
chore(docker): optimize image size with multi-stage build and remove …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,27 @@
-# Use the official Python 3.9 image
-FROM python:3.9
+# Build stage - install dependencies that need compilation
+FROM python:3.9-slim AS builder
+
+WORKDIR /app
+
+# Install build dependencies for C extensions (numpy, aiohttp, etc.)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir --prefix=/install -r /app/requirements.txt
+
+# Final stage - slim runtime image
+FROM python:3.9-slim
 
 ARG BUILD_SHA=unknown
 ARG BUILD_TIMESTAMP=unknown
 
-# Set the working directory
 WORKDIR /app
 
-# Copy the current directory contents into the container at /app
-COPY requirements.txt /app/requirements.txt
-COPY gunicorn_conf.py /app/gunicorn_conf.py
-
-# Install dependencies
-RUN pip install --no-cache-dir -r /app/requirements.txt
+# Copy installed packages from builder
+COPY --from=builder /install /usr/local
 
 # Copy the application code
 COPY . /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-aiocron==1.6
-aiofiles==0.7.0
 aiohttp==3.7.4.post0
 aiosignal==1.3.1
 async-timeout==3.0.1
@@ -10,7 +8,6 @@ certifi==2023.7.22
 charset-normalizer==3.2.0
 click==8.1.7
 discord.py==1.7.3
-ffmpeg-python==0.2.0
 Flask==2.3.3
 Flask-Discord==0.1.69
 Flask-Login==0.6.2
@@ -18,13 +15,11 @@ frozenlist==1.4.0
 future==0.18.3
 gunicorn==21.2.0
 idna==3.4
-imageio-ffmpeg==0.4.8
 importlib-metadata==6.8.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
 MarkupSafe==2.1.3
 multidict==6.0.4
-numpy==1.25.2
 oauthlib==3.2.2
 packaging==23.1
 PyJWT==2.8.0


### PR DESCRIPTION
…unused dependencies

- Implement multi-stage Docker build to separate compilation from runtime
- Create builder stage with gcc and python3-dev for C extension compilation
- Use python:3.9-slim for final stage to reduce image footprint
- Copy pre-compiled packages from builder to final image
- Remove unused dependencies: aiocron, aiofiles, ffmpeg-python, imageio-ffmpeg, numpy
- Clean up Dockerfile comments and simplify structure
- Reduces final image size by avoiding runtime compilation tools and unused packages