### PR TITLE
style(templates): restructure team lineup layout with side-by-side ki…

### DIFF
--- a/templates/result.html
+++ b/templates/result.html
@@ -64,49 +64,53 @@
                                 <br>
                                 {% endif %}
 
-                                <div class="section-label"><i class="fas fa-shield-alt"></i> Team A Kit</div>
-                                <div style="margin-bottom: 12px;">
-                                    <select class="form-control" name="ImageA" id="changeImageA">
-                                        <option value="teama" {% if selected_coloura == 'teama' or selected_coloura is not defined %}selected{% endif %}>teama</option>
-                                        <option value="blue" {% if selected_coloura == 'blue' %}selected{% endif %}>blue</option>
-                                        <option value="white" {% if selected_coloura == 'white' %}selected{% endif %}>white</option>
-                                        <option value="black" {% if selected_coloura == 'black' %}selected{% endif %}>black</option>
-                                        <option value="red" {% if selected_coloura == 'red' %}selected{% endif %}>red</option>
-                                        <option value="green" {% if selected_coloura == 'green' %}selected{% endif %}>green</option>
-                                        <option value="pink" {% if selected_coloura == 'pink' %}selected{% endif %}>pink</option>
-                                        <option value="stripes" {% if selected_coloura == 'stripes' %}selected{% endif %}>stripes</option>
-                                        <option value="yellow" {% if selected_coloura == 'yellow' %}selected{% endif %}>yellow</option>
-                                        <option value="multicoloured" {% if selected_coloura == 'multicoloured' %}selected{% endif %}>multicoloured</option>
-                                        <option value="darrenschoice" {% if selected_coloura == 'darrenschoice' %}selected{% endif %}>darrenschoice</option>
-                                    </select>
-                                </div>
-                                <p id="rcorners" style="margin: 0 auto 1.25rem;">
-                                    <img id="imageA" src='/static/teama.png' width="90" height="100" class="center">
-                                    <b>Team A ({{ scorea }}):</b><br>
-                                    {% for player in teama %}{{ player }}<br>{% endfor %}
-                                </p>
+                                <h3 class="manual-team-heading">Lineup for {{ date|format_date }}:</h3>
 
-                                <div class="section-label"><i class="fas fa-shield-alt"></i> Team B Kit</div>
-                                <div style="margin-bottom: 12px;">
-                                    <select class="form-control" name="ImageB" id="changeImageB">
-                                        <option value="teamb" {% if selected_colourb == 'teamb' or selected_colourb is not defined %}selected{% endif %}>teamb</option>
-                                        <option value="blue" {% if selected_colourb == 'blue' %}selected{% endif %}>blue</option>
-                                        <option value="white" {% if selected_colourb == 'white' %}selected{% endif %}>white</option>
-                                        <option value="black" {% if selected_colourb == 'black' %}selected{% endif %}>black</option>
-                                        <option value="red" {% if selected_colourb == 'red' %}selected{% endif %}>red</option>
-                                        <option value="green" {% if selected_colourb == 'green' %}selected{% endif %}>green</option>
-                                        <option value="pink" {% if selected_colourb == 'pink' %}selected{% endif %}>pink</option>
-                                        <option value="stripes" {% if selected_colourb == 'stripes' %}selected{% endif %}>stripes</option>
-                                        <option value="yellow" {% if selected_colourb == 'yellow' %}selected{% endif %}>yellow</option>
-                                        <option value="multicoloured" {% if selected_colourb == 'multicoloured' %}selected{% endif %}>multicoloured</option>
-                                        <option value="darrenschoice" {% if selected_colourb == 'darrenschoice' %}selected{% endif %}>darrenschoice</option>
-                                    </select>
+                                <div id="rcorners" style="margin: 1rem auto; display: flex; justify-content: space-between; align-items: flex-start;">
+                                    <div style="flex: 1; min-width: 0; text-align: left;">
+                                        <span class="section-label" style="margin: 0 0 0.5rem;">Team A ({{ scorea }})</span><br>
+                                        {% for player in teama %}{{ player }}<br>{% endfor %}
+                                    </div>
+                                    <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 8px; margin-left: 15px; flex-shrink: 0;">
+                                        <select class="form-control" name="ImageA" id="changeImageA" style="width: 90px !important; max-width: 90px !important; min-height: 34px !important; height: 34px !important; padding: 0 8px !important; font-size: 0.7rem !important; text-align: center; text-align-last: center; border: 2px solid var(--purple-400); border-radius: 8px;">
+                                            <option value="teama" {% if selected_coloura == 'teama' or selected_coloura is not defined %}selected{% endif %}>teama</option>
+                                            <option value="blue" {% if selected_coloura == 'blue' %}selected{% endif %}>blue</option>
+                                            <option value="white" {% if selected_coloura == 'white' %}selected{% endif %}>white</option>
+                                            <option value="black" {% if selected_coloura == 'black' %}selected{% endif %}>black</option>
+                                            <option value="red" {% if selected_coloura == 'red' %}selected{% endif %}>red</option>
+                                            <option value="green" {% if selected_coloura == 'green' %}selected{% endif %}>green</option>
+                                            <option value="pink" {% if selected_coloura == 'pink' %}selected{% endif %}>pink</option>
+                                            <option value="stripes" {% if selected_coloura == 'stripes' %}selected{% endif %}>stripes</option>
+                                            <option value="yellow" {% if selected_coloura == 'yellow' %}selected{% endif %}>yellow</option>
+                                            <option value="multicoloured" {% if selected_coloura == 'multicoloured' %}selected{% endif %}>multi</option>
+                                            <option value="darrenschoice" {% if selected_coloura == 'darrenschoice' %}selected{% endif %}>darren's</option>
+                                        </select>
+                                        <img id="imageA" src='/static/teama.png' width="90" height="100" style="border-radius: 15px; object-fit: contain;">
+                                    </div>
                                 </div>
-                                <p id="rcorners" style="margin: 0 auto 1.5rem;">
-                                    <img id="imageB" src='/static/teamb.png' width="90" height="100" class="center">
-                                    <b>Team B ({{ scoreb }}):</b><br>
-                                    {% for player in teamb %}{{ player }}<br>{% endfor %}
-                                </p>
+
+                                <div id="rcorners" style="margin: 1rem auto; display: flex; justify-content: space-between; align-items: flex-start;">
+                                    <div style="flex: 1; min-width: 0; text-align: left;">
+                                        <span class="section-label" style="margin: 0 0 0.5rem;">Team B ({{ scoreb }})</span><br>
+                                        {% for player in teamb %}{{ player }}<br>{% endfor %}
+                                    </div>
+                                    <div style="display: flex; flex-direction: column; align-items: flex-end; gap: 8px; margin-left: 15px; flex-shrink: 0;">
+                                        <select class="form-control" name="ImageB" id="changeImageB" style="width: 90px !important; max-width: 90px !important; min-height: 34px !important; height: 34px !important; padding: 0 8px !important; font-size: 0.7rem !important; text-align: center; text-align-last: center; border: 2px solid var(--purple-400); border-radius: 8px;">
+                                            <option value="teamb" {% if selected_colourb == 'teamb' or selected_colourb is not defined %}selected{% endif %}>teamb</option>
+                                            <option value="blue" {% if selected_colourb == 'blue' %}selected{% endif %}>blue</option>
+                                            <option value="white" {% if selected_colourb == 'white' %}selected{% endif %}>white</option>
+                                            <option value="black" {% if selected_colourb == 'black' %}selected{% endif %}>black</option>
+                                            <option value="red" {% if selected_colourb == 'red' %}selected{% endif %}>red</option>
+                                            <option value="green" {% if selected_colourb == 'green' %}selected{% endif %}>green</option>
+                                            <option value="pink" {% if selected_colourb == 'pink' %}selected{% endif %}>pink</option>
+                                            <option value="stripes" {% if selected_colourb == 'stripes' %}selected{% endif %}>stripes</option>
+                                            <option value="yellow" {% if selected_colourb == 'yellow' %}selected{% endif %}>yellow</option>
+                                            <option value="multicoloured" {% if selected_colourb == 'multicoloured' %}selected{% endif %}>multi</option>
+                                            <option value="darrenschoice" {% if selected_colourb == 'darrenschoice' %}selected{% endif %}>darren's</option>
+                                        </select>
+                                        <img id="imageB" src='/static/teamb.png' width="90" height="100" style="border-radius: 15px; object-fit: contain;">
+                                    </div>
+                                </div>
 
                                 <div class="section-label"><i class="fas fa-database"></i> Confirm</div>
                                 <div style="display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; margin-top: 8px;">


### PR DESCRIPTION
…t selectors

- Reorganize Team A and Team B sections into flex-based layouts with lineups on left and kit selectors on right
- Reduce kit selector dropdown width to 90px with centered text and consistent styling
- Add date heading "Lineup for [date]:" above team sections
- Shorten multicolor and darrenschoice option labels for compact display
- Move team kit images inline with selectors using flexbox column layout
- Remove redundant section label icons and adjust spacing for improved visual hierarchy